### PR TITLE
[YITEAM-45] 소셜 로그인

### DIFF
--- a/src/main/java/com/yapp/ios1/advice/AdviceController.java
+++ b/src/main/java/com/yapp/ios1/advice/AdviceController.java
@@ -1,6 +1,8 @@
 package com.yapp.ios1.advice;
 
+import com.yapp.ios1.common.ResponseMessage;
 import com.yapp.ios1.dto.ResponseDto;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -11,6 +13,7 @@ import java.sql.SQLException;
 /**
  * created by jg 2021/04/11
  */
+@Slf4j
 @RestControllerAdvice
 public class AdviceController {
 
@@ -22,7 +25,8 @@ public class AdviceController {
 
     @ExceptionHandler(SQLException.class)
     public ResponseEntity<ResponseDto> sqlException(SQLException e) {
+        log.info(e.getMessage());
         return ResponseEntity.ok()
-                .body(ResponseDto.of(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage()));
+                .body(ResponseDto.of(HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.DATABASE_ERROR));
     }
 }

--- a/src/main/java/com/yapp/ios1/advice/AdviceController.java
+++ b/src/main/java/com/yapp/ios1/advice/AdviceController.java
@@ -19,6 +19,7 @@ public class AdviceController {
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ResponseDto> tokenException(IllegalArgumentException e) {
+        e.printStackTrace();
         return ResponseEntity.ok()
                 .body(ResponseDto.of(HttpStatus.UNAUTHORIZED, e.getMessage()));
     }

--- a/src/main/java/com/yapp/ios1/advice/UserAdviceController.java
+++ b/src/main/java/com/yapp/ios1/advice/UserAdviceController.java
@@ -1,5 +1,6 @@
 package com.yapp.ios1.advice;
 
+import com.yapp.ios1.common.ResponseMessage;
 import com.yapp.ios1.dto.ResponseDto;
 import com.yapp.ios1.exception.user.PasswordNotMatchException;
 import com.yapp.ios1.exception.user.UserDuplicatedException;
@@ -8,6 +9,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.HttpClientErrorException;
 
 /**
  * created by jg 2021/05/05
@@ -34,4 +36,10 @@ public class UserAdviceController {
                 .body(ResponseDto.of(HttpStatus.BAD_REQUEST, e.getMessage()));
     }
 
+    // 소셜 로그인
+    @ExceptionHandler(HttpClientErrorException.class)
+    public ResponseEntity<ResponseDto> socialException() {
+        return ResponseEntity.ok()
+                .body(ResponseDto.of(HttpStatus.BAD_REQUEST, ResponseMessage.SOCIAL_LOGIN_ERROR));
+    }
 }

--- a/src/main/java/com/yapp/ios1/common/ResponseMessage.java
+++ b/src/main/java/com/yapp/ios1/common/ResponseMessage.java
@@ -9,4 +9,7 @@ public class ResponseMessage {
 
     // Bucket Home
     public static final String GET_BUCKET_LIST = "버킷 리스트 조회 성공입니다.";
+
+    public static final String SOCIAL_LOGIN_ERROR = "소셜 로그인 실패입니다.";
+    public static final String DATABASE_ERROR = "데이터베이스 오류입니다.";
 }

--- a/src/main/java/com/yapp/ios1/common/ResponseMessage.java
+++ b/src/main/java/com/yapp/ios1/common/ResponseMessage.java
@@ -10,6 +10,11 @@ public class ResponseMessage {
     // Bucket Home
     public static final String GET_BUCKET_LIST = "버킷 리스트 조회 성공입니다.";
 
+    // Login
+    public static final String LOGIN_SUCCESS = "액세스 토큰 발급";
+    public static final String BAD_SOCIAL_TYPE = "잘못된 소셜 타입입니다.";
     public static final String SOCIAL_LOGIN_ERROR = "소셜 로그인 실패입니다.";
+
     public static final String DATABASE_ERROR = "데이터베이스 오류입니다.";
+
 }

--- a/src/main/java/com/yapp/ios1/config/RestTemplateConfig.java
+++ b/src/main/java/com/yapp/ios1/config/RestTemplateConfig.java
@@ -1,0 +1,32 @@
+package com.yapp.ios1.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+/**
+ * created by ayoung 2021/05/06
+ */
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder
+                .requestFactory(() -> new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory()))
+                .setConnectTimeout(Duration.ofMillis(5000)) // connection-timeout
+                .setReadTimeout(Duration.ofMillis(5000)) // read-timeout
+                .additionalMessageConverters(new StringHttpMessageConverter(StandardCharsets.UTF_8))
+                .build();
+    }
+}
+
+

--- a/src/main/java/com/yapp/ios1/controller/OauthController.java
+++ b/src/main/java/com/yapp/ios1/controller/OauthController.java
@@ -1,0 +1,56 @@
+package com.yapp.ios1.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.yapp.ios1.dto.JwtPayload;
+import com.yapp.ios1.dto.ResponseDto;
+import com.yapp.ios1.dto.user.social.SocialType;
+import com.yapp.ios1.dto.user.social.UserCheckDto;
+import com.yapp.ios1.dto.user.TokenDto;
+import com.yapp.ios1.service.JwtService;
+import com.yapp.ios1.service.OauthService;
+import io.swagger.annotations.Api;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.sql.SQLException;
+
+/**
+ * created by ayoung 2021/05/04
+ */
+@RequiredArgsConstructor
+@Slf4j
+@RestController
+@RequestMapping("/api/v2/social")
+@Api(tags = "Social Login")
+public class OauthController {
+
+    private final OauthService oauthService;
+    private final JwtService jwtService;
+
+    @PostMapping("")
+    public ResponseEntity<ResponseDto> socialLogin(@RequestParam("social_type") String socialType, @RequestBody TokenDto tokenDto) throws JsonProcessingException, SQLException {
+
+        UserCheckDto checkDto;
+
+        switch (socialType) {
+            case SocialType.GOOGLE:
+                checkDto = oauthService.getGoogleUser(tokenDto.getAccessToken());
+                break;
+            case SocialType.KAKAO:
+                checkDto = oauthService.getKakaoUser(tokenDto.getAccessToken());
+                break;
+            case SocialType.APPLE:
+                checkDto = oauthService.getAppleUser(tokenDto.getAccessToken());
+                break;
+            default:
+                return ResponseEntity.ok(ResponseDto.of(HttpStatus.BAD_REQUEST, "잘못된 소셜 타입입니다."));
+        }
+
+        String token = jwtService.createToken(new JwtPayload(checkDto.getUserId()));
+        ResponseDto response = ResponseDto.of(HttpStatus.valueOf(checkDto.getStatus()), "액세스 토큰 발급", new TokenDto(token));
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/yapp/ios1/controller/OauthController.java
+++ b/src/main/java/com/yapp/ios1/controller/OauthController.java
@@ -3,7 +3,6 @@ package com.yapp.ios1.controller;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.yapp.ios1.dto.JwtPayload;
 import com.yapp.ios1.dto.ResponseDto;
-import com.yapp.ios1.dto.user.social.SocialType;
 import com.yapp.ios1.dto.user.social.UserCheckDto;
 import com.yapp.ios1.dto.user.TokenDto;
 import com.yapp.ios1.service.JwtService;
@@ -11,11 +10,12 @@ import com.yapp.ios1.service.OauthService;
 import io.swagger.annotations.Api;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.sql.SQLException;
+
+import static com.yapp.ios1.common.ResponseMessage.LOGIN_SUCCESS;
 
 /**
  * created by ayoung 2021/05/04
@@ -30,27 +30,13 @@ public class OauthController {
     private final OauthService oauthService;
     private final JwtService jwtService;
 
-    @PostMapping("")
-    public ResponseEntity<ResponseDto> socialLogin(@RequestParam("social_type") String socialType, @RequestBody TokenDto tokenDto) throws JsonProcessingException, SQLException {
-
-        UserCheckDto checkDto;
-
-        switch (socialType) {
-            case SocialType.GOOGLE:
-                checkDto = oauthService.getGoogleUser(tokenDto.getAccessToken());
-                break;
-            case SocialType.KAKAO:
-                checkDto = oauthService.getKakaoUser(tokenDto.getAccessToken());
-                break;
-            case SocialType.APPLE:
-                checkDto = oauthService.getAppleUser(tokenDto.getAccessToken());
-                break;
-            default:
-                return ResponseEntity.ok(ResponseDto.of(HttpStatus.BAD_REQUEST, "잘못된 소셜 타입입니다."));
-        }
+    @PostMapping("/{social_type}")
+    public ResponseEntity<ResponseDto> socialLogin(@PathVariable("social_type") String socialType, @RequestBody TokenDto tokenDto) throws JsonProcessingException, SQLException {
+        UserCheckDto checkDto = oauthService.getSocialUser(socialType, tokenDto.getAccessToken());
 
         String token = jwtService.createToken(new JwtPayload(checkDto.getUserId()));
-        ResponseDto response = ResponseDto.of(HttpStatus.valueOf(checkDto.getStatus()), "액세스 토큰 발급", new TokenDto(token));
+
+        ResponseDto response = ResponseDto.of(checkDto.getStatus(), LOGIN_SUCCESS, new TokenDto(token));
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/yapp/ios1/controller/UserController.java
+++ b/src/main/java/com/yapp/ios1/controller/UserController.java
@@ -9,7 +9,6 @@ import com.yapp.ios1.exception.user.UserDuplicatedException;
 import com.yapp.ios1.service.JwtService;
 import com.yapp.ios1.service.UserService;
 import com.yapp.ios1.utils.auth.Auth;
-import com.yapp.ios1.utils.auth.UserContext;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -89,7 +88,7 @@ public class UserController {
             throw new UserDuplicatedException("이미 존재하는 계정입니다.");
         }
 
-        userService.signUp(signUpDto);
+        userService.signUp(UserDto.of(signUpDto));
         ResponseDto response = ResponseDto.of(HttpStatus.CREATED, "회원가입이 완료되었습니다.");
         return ResponseEntity.ok().body(response);
     }

--- a/src/main/java/com/yapp/ios1/dto/user/SignUpDto.java
+++ b/src/main/java/com/yapp/ios1/dto/user/SignUpDto.java
@@ -1,5 +1,6 @@
 package com.yapp.ios1.dto.user;
 
+import com.yapp.ios1.dto.user.social.SocialType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,7 +13,7 @@ import lombok.Getter;
 @Getter
 public class SignUpDto {
     private String email;
-    private String socialType;
+    private SocialType socialType;
     private String password;
     private String nickname;
     private String intro;

--- a/src/main/java/com/yapp/ios1/dto/user/SignUpDto.java
+++ b/src/main/java/com/yapp/ios1/dto/user/SignUpDto.java
@@ -1,20 +1,20 @@
 package com.yapp.ios1.dto.user;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 /**
  * created by ayoung 2021/04/14
  */
 @AllArgsConstructor
+@Builder
 @Getter
 public class SignUpDto {
     private String email;
+    private String socialType;
     private String password;
     private String nickname;
     private String intro;
-
-    public void setPassword(String password) {
-        this.password = password;
-    }
+    private String socialId;
 }

--- a/src/main/java/com/yapp/ios1/dto/user/TokenDto.java
+++ b/src/main/java/com/yapp/ios1/dto/user/TokenDto.java
@@ -1,10 +1,12 @@
 package com.yapp.ios1.dto.user;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 /**
  * created by jg 2021/04/11
  */
+@NoArgsConstructor
 @Getter
 public class TokenDto {
     private String accessToken;

--- a/src/main/java/com/yapp/ios1/dto/user/UserDto.java
+++ b/src/main/java/com/yapp/ios1/dto/user/UserDto.java
@@ -1,10 +1,9 @@
 package com.yapp.ios1.dto.user;
 
-import com.google.gson.annotations.SerializedName;
+import com.yapp.ios1.dto.user.social.SocialType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 /**
  * created by jg 2021/03/28
@@ -15,14 +14,14 @@ import lombok.NoArgsConstructor;
 public class UserDto {
     private Long id;
     private String email;
-    private String socialType;
+    private SocialType socialType;
     private String nickname;
     private String password;
     private String intro;
     private String createdDate;
     private String socialId;
 
-    public UserDto(String email, String socialType, String nickname, String password, String intro) {
+    public UserDto(String email, SocialType socialType, String nickname, String password, String intro) {
         this.email = email;
         this.socialType = socialType;
         this.nickname = nickname;

--- a/src/main/java/com/yapp/ios1/dto/user/UserDto.java
+++ b/src/main/java/com/yapp/ios1/dto/user/UserDto.java
@@ -1,5 +1,6 @@
 package com.yapp.ios1.dto.user;
 
+import com.google.gson.annotations.SerializedName;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,6 +20,7 @@ public class UserDto {
     private String password;
     private String intro;
     private String createdDate;
+    private String socialId;
 
     public UserDto(String email, String socialType, String nickname, String password, String intro) {
         this.email = email;
@@ -34,6 +36,12 @@ public class UserDto {
                 .nickname(signUpDto.getNickname())
                 .password(signUpDto.getPassword())
                 .intro(signUpDto.getIntro())
+                .socialType(signUpDto.getSocialType())
+                .socialId(signUpDto.getSocialId())
                 .build();
+    }
+
+    public void encodePassword(String password) {
+        this.password = password;
     }
 }

--- a/src/main/java/com/yapp/ios1/dto/user/social/GoogleProfileDto.java
+++ b/src/main/java/com/yapp/ios1/dto/user/social/GoogleProfileDto.java
@@ -1,0 +1,29 @@
+package com.yapp.ios1.dto.user.social;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * created by ayoung 2021/05/04
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class GoogleProfileDto {
+    private String sub;
+
+    private String name;
+
+    private String given_name;
+
+    private String family_name;
+
+    private String picture;
+
+    private String email;
+
+    private Boolean email_verified;
+
+    private String locale;
+}

--- a/src/main/java/com/yapp/ios1/dto/user/social/GoogleProfileDto.java
+++ b/src/main/java/com/yapp/ios1/dto/user/social/GoogleProfileDto.java
@@ -1,13 +1,11 @@
 package com.yapp.ios1.dto.user.social;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
  * created by ayoung 2021/05/04
  */
-@AllArgsConstructor
 @NoArgsConstructor
 @Getter
 public class GoogleProfileDto {

--- a/src/main/java/com/yapp/ios1/dto/user/social/SocialType.java
+++ b/src/main/java/com/yapp/ios1/dto/user/social/SocialType.java
@@ -1,0 +1,10 @@
+package com.yapp.ios1.dto.user.social;
+
+/**
+ * created by ayoung 2021/05/06
+ */
+public class SocialType {
+    public static final String GOOGLE = "GOOGLE";
+    public static final String KAKAO = "KAKAO";
+    public static final String APPLE = "APPLE";
+}

--- a/src/main/java/com/yapp/ios1/dto/user/social/SocialType.java
+++ b/src/main/java/com/yapp/ios1/dto/user/social/SocialType.java
@@ -3,8 +3,6 @@ package com.yapp.ios1.dto.user.social;
 /**
  * created by ayoung 2021/05/06
  */
-public class SocialType {
-    public static final String GOOGLE = "GOOGLE";
-    public static final String KAKAO = "KAKAO";
-    public static final String APPLE = "APPLE";
+public enum SocialType {
+    KAKAO, GOOGLE, APPLE
 }

--- a/src/main/java/com/yapp/ios1/dto/user/social/UserCheckDto.java
+++ b/src/main/java/com/yapp/ios1/dto/user/social/UserCheckDto.java
@@ -2,6 +2,7 @@ package com.yapp.ios1.dto.user.social;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 /**
  * created by ayoung 2021/05/05
@@ -9,6 +10,6 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class UserCheckDto {
-    private int status;
+    private HttpStatus status;
     private Long userId;
 }

--- a/src/main/java/com/yapp/ios1/dto/user/social/UserCheckDto.java
+++ b/src/main/java/com/yapp/ios1/dto/user/social/UserCheckDto.java
@@ -1,0 +1,14 @@
+package com.yapp.ios1.dto.user.social;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * created by ayoung 2021/05/05
+ */
+@AllArgsConstructor
+@Getter
+public class UserCheckDto {
+    private int status;
+    private Long userId;
+}

--- a/src/main/java/com/yapp/ios1/mapper/UserMapper.java
+++ b/src/main/java/com/yapp/ios1/mapper/UserMapper.java
@@ -20,5 +20,5 @@ public interface UserMapper {
 
     Optional<UserDto> findByEmailOrNickname(@Param("email") String email, @Param("nickname") String nickname);
 
-    int signUp(UserDto userDto);
+    void signUp(UserDto userDto);
 }

--- a/src/main/java/com/yapp/ios1/service/OauthService.java
+++ b/src/main/java/com/yapp/ios1/service/OauthService.java
@@ -1,0 +1,78 @@
+package com.yapp.ios1.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yapp.ios1.dto.user.SignUpDto;
+import com.yapp.ios1.dto.user.social.GoogleProfileDto;
+import com.yapp.ios1.dto.user.social.SocialType;
+import com.yapp.ios1.dto.user.social.UserCheckDto;
+import com.yapp.ios1.dto.user.UserDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
+import java.util.Optional;
+
+/**
+ * created by ayoung 2021/05/04
+ */
+@RequiredArgsConstructor
+@Service
+public class OauthService {
+
+    private final UserService userService;
+    private final RestTemplate restTemplate;
+
+    @Value("${buok.key}")
+    private String BUOK_KEY;
+
+    // 구글 로그인
+    public UserCheckDto getGoogleUser(String accessToken) throws JsonProcessingException, SQLException, HttpClientErrorException {
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
+        headers.add("Authorization", "Bearer " + accessToken);
+
+        HttpEntity<MultiValueMap<String, String>> googleProfileRequest = new HttpEntity<>(headers);
+
+        ResponseEntity<String> restResponse = restTemplate.exchange(
+                "https://www.googleapis.com/oauth2/v3/userinfo",
+                HttpMethod.POST,
+                googleProfileRequest,
+                String.class
+        );
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        // 구글 프로필 정보
+        GoogleProfileDto profile = objectMapper.readValue(restResponse.getBody(), GoogleProfileDto.class);
+
+        Optional<UserDto> optionalUser = userService.emailCheck(profile.getEmail());
+        if (optionalUser.isEmpty()) { // 회원가입 처리
+            SignUpDto signUpDto = SignUpDto.builder()
+                    .email(profile.getEmail())
+                    .socialType(SocialType.GOOGLE)
+                    .password(BUOK_KEY)
+                    .socialId(profile.getSub())
+                    .build();
+            return new UserCheckDto(201, userService.signUp(UserDto.of(signUpDto)));
+        } else {
+            return new UserCheckDto(200, optionalUser.get().getId());
+        }
+    }
+
+    // 카카오 로그인
+    public UserCheckDto getKakaoUser(String accessToken) {
+        return null;
+    }
+
+    // 애플 로그인
+    public UserCheckDto getAppleUser(String accessToken) {
+        return null;
+    }
+}

--- a/src/main/java/com/yapp/ios1/service/UserService.java
+++ b/src/main/java/com/yapp/ios1/service/UserService.java
@@ -1,7 +1,6 @@
 package com.yapp.ios1.service;
 
 import com.yapp.ios1.dto.user.SignInDto;
-import com.yapp.ios1.dto.user.SignUpDto;
 import com.yapp.ios1.dto.user.UserDto;
 import com.yapp.ios1.exception.user.PasswordNotMatchException;
 import com.yapp.ios1.exception.user.UserNotFoundException;
@@ -68,16 +67,12 @@ public class UserService {
     /**
      * 회원가입
      *
-     * @param signUpDto 회원가입 정보
+     * @param userDto 회원가입 정보
      */
-    public void signUp(SignUpDto signUpDto) throws SQLException {
-        try {
-            signUpDto.setPassword(passwordEncoder.encode(signUpDto.getPassword()));
-            UserDto userDto = UserDto.of(signUpDto);
-            userMapper.signUp(userDto);
-        } catch (Exception e) {
-            throw new SQLException("데이터베이스 오류입니다.");
-        }
+    public Long signUp(UserDto userDto) {
+        userDto.encodePassword(passwordEncoder.encode(userDto.getPassword()));
+        userMapper.signUp(userDto);
+        return userDto.getId();
     }
 
     /**

--- a/src/main/resources/mapper/userMapper.xml
+++ b/src/main/resources/mapper/userMapper.xml
@@ -3,8 +3,8 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.yapp.ios1.mapper.UserMapper">
-    <insert id="signUp">
-        INSERT INTO user (email, password, nickname, intro) VALUES(#{email}, #{password}, #{nickname}, #{intro})
+    <insert id="signUp" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO user (email, social_type, password, nickname, intro, social_id) VALUES(#{email}, #{socialType}, #{password}, #{nickname}, #{intro}, #{socialId})
     </insert>
 
     <select id="findByUserId" resultType="UserDto">

--- a/src/test/java/com/yapp/ios1/dto/ResponseDtoTest.java
+++ b/src/test/java/com/yapp/ios1/dto/ResponseDtoTest.java
@@ -1,6 +1,7 @@
 package com.yapp.ios1.dto;
 
 import com.yapp.ios1.dto.user.UserDto;
+import com.yapp.ios1.dto.user.social.SocialType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -17,7 +18,7 @@ public class ResponseDtoTest {
     public void responseTest() {
 
         //given
-        UserDto userDto = new UserDto("ayong703@gmail.com", "GOOGLE", "문아영","test", "test");
+        UserDto userDto = new UserDto("ayong703@gmail.com", SocialType.GOOGLE, "문아영","test", "test");
 
         //when
         ResponseDto res1 = ResponseDto.of(HttpStatus.OK, "응답 테스트 메세지1", userDto);


### PR DESCRIPTION
- 일단 구글 로그인 먼저 구현해봤습니다! 
- 컨트롤러단에서 소셜타입을 구분해서 서비스 메서드를 호출할지 아니면 서비스단에서 구분하는 게 좋을지 고민 중입니다!
- uri 
```
1. [POST] /api/v2/social?social_type=GOOGLE -> body에 소셜액세스토큰 담음
2. [POST] /api/v2/social/google -> body에 소셜액세스토큰 담음
3. [POST] /api/v2/social -> body에 social_type과 소셜액세스토큰 담음
```
지금은 일단 1번으로 하긴 했는데 3개 중에 고민하고 있습니다..!
- 이메일 존재 O(기존 회원)
```json
{
    "status": 200,
    "message": "액세스 토큰 발급",
    "data": {
        "accessToken": "eyJh~"
    }
}
```
- 이메일 존재 X -> 회원가입을 시킨 후 userIdx를 받아 액세스 토큰을 발급한다.
```json
{
    "status": 201,
    "message": "액세스 토큰 발급",
    "data": {
        "accessToken": "eyJh~"
    }
}
```

- 아직 업데이트 기능은 구현하지 않았습니다. 소셜 로그인 완성할 때 같이 구현하겠습니다
- 소셜 서버에 접근할 때 생기는 예외 ```HttpClientErrorException``` 처리해놨습니다 (UserAdviceController 클래스)
- UserService의 signup 메서드 try, catch문 없애고, AdviceController에 공통으로 SQLException 처리해놓게 했는데 봐주세요! 
- SocialType 클래스에 GOOGLE, KAKAO, APPLE 문자열 저장해놨습니다
- 패스워드 rawPassword null 이면 안돼서 따로 Buok key 임의로 만들어놨습니다 공유해드릴게요!