### PR TITLE
[YITEAM-52] 애플 로그인 구현

### DIFF
--- a/src/main/java/com/yapp/ios1/advice/AdviceController.java
+++ b/src/main/java/com/yapp/ios1/advice/AdviceController.java
@@ -3,6 +3,7 @@ package com.yapp.ios1.advice;
 import com.yapp.ios1.common.ResponseMessage;
 import com.yapp.ios1.dto.ResponseDto;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.ibatis.executor.ExecutorException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -28,5 +29,18 @@ public class AdviceController {
         log.info(e.getMessage());
         return ResponseEntity.ok()
                 .body(ResponseDto.of(HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.DATABASE_ERROR));
+    }
+
+    @ExceptionHandler(ExecutorException.class)
+    public ResponseEntity<ResponseDto> executorException(ExecutorException e) {
+        log.info(e.getMessage());
+        return ResponseEntity.ok()
+                .body(ResponseDto.of(HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.DATABASE_ERROR));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ResponseDto> exception(Exception e) {
+        return ResponseEntity.ok()
+                .body(ResponseDto.of(HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.INTERNAL_SERVER_ERROR));
     }
 }

--- a/src/main/java/com/yapp/ios1/advice/AdviceController.java
+++ b/src/main/java/com/yapp/ios1/advice/AdviceController.java
@@ -38,9 +38,4 @@ public class AdviceController {
                 .body(ResponseDto.of(HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.DATABASE_ERROR));
     }
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ResponseDto> exception(Exception e) {
-        return ResponseEntity.ok()
-                .body(ResponseDto.of(HttpStatus.INTERNAL_SERVER_ERROR, ResponseMessage.INTERNAL_SERVER_ERROR));
-    }
 }

--- a/src/main/java/com/yapp/ios1/advice/UserAdviceController.java
+++ b/src/main/java/com/yapp/ios1/advice/UserAdviceController.java
@@ -11,6 +11,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.client.HttpClientErrorException;
 
+import java.text.ParseException;
+
 /**
  * created by jg 2021/05/05
  */
@@ -41,5 +43,12 @@ public class UserAdviceController {
     public ResponseEntity<ResponseDto> socialException() {
         return ResponseEntity.ok()
                 .body(ResponseDto.of(HttpStatus.BAD_REQUEST, ResponseMessage.SOCIAL_LOGIN_ERROR));
+    }
+
+    // JWT Parse 에러
+    @ExceptionHandler(ParseException.class) 
+    public ResponseEntity<ResponseDto> jwtException() {
+        return ResponseEntity.ok()
+                .body(ResponseDto.of(HttpStatus.BAD_REQUEST, ResponseMessage.BAD_JWT));
     }
 }

--- a/src/main/java/com/yapp/ios1/common/ResponseMessage.java
+++ b/src/main/java/com/yapp/ios1/common/ResponseMessage.java
@@ -18,6 +18,7 @@ public class ResponseMessage {
     // Login
     public static final String LOGIN_SUCCESS = "액세스 토큰 발급";
     public static final String SOCIAL_LOGIN_ERROR = "소셜 로그인 실패입니다.";
+    public static final String EXIST_EMAIL = "존재하는 이메일입니다.";
     public static final String EXIST_USER = "존재하는 회원입니다.";
     public static final String NOT_EXIST_USER = "존재하지 않는 회원입니다.";
     public static final String SIGN_UP_SUCCESS = "회원가입 성공입니다.";

--- a/src/main/java/com/yapp/ios1/common/ResponseMessage.java
+++ b/src/main/java/com/yapp/ios1/common/ResponseMessage.java
@@ -23,6 +23,7 @@ public class ResponseMessage {
     public static final String SIGN_UP_SUCCESS = "회원가입 성공입니다.";
     public static final String NOT_MATCH_PASSWORD = "비밀번호 오류입니다.";
     public static final String BAD_SOCIAL_TYPE = "잘못된 소셜 타입입니다.";
+    public static final String BAD_JWT = "잘못된 JWT 입니다.";
 
     // User
     public static final String GET_MY_INFO = "마이페이지 정보입니다.";

--- a/src/main/java/com/yapp/ios1/controller/OauthController.java
+++ b/src/main/java/com/yapp/ios1/controller/OauthController.java
@@ -3,6 +3,7 @@ package com.yapp.ios1.controller;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.yapp.ios1.dto.JwtPayload;
 import com.yapp.ios1.dto.ResponseDto;
+import com.yapp.ios1.dto.user.social.AppleRequestDto;
 import com.yapp.ios1.dto.user.social.UserCheckDto;
 import com.yapp.ios1.dto.user.TokenDto;
 import com.yapp.ios1.service.JwtService;
@@ -14,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.sql.SQLException;
+import java.text.ParseException;
 
 import static com.yapp.ios1.common.ResponseMessage.LOGIN_SUCCESS;
 
@@ -33,6 +35,16 @@ public class OauthController {
     @PostMapping("/{social_type}")
     public ResponseEntity<ResponseDto> socialLogin(@PathVariable("social_type") String socialType, @RequestBody TokenDto tokenDto) throws JsonProcessingException, SQLException {
         UserCheckDto checkDto = oauthService.getSocialUser(socialType, tokenDto.getAccessToken());
+
+        String token = jwtService.createToken(new JwtPayload(checkDto.getUserId()));
+
+        ResponseDto response = ResponseDto.of(checkDto.getStatus(), LOGIN_SUCCESS, new TokenDto(token));
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/apple")
+    public ResponseEntity<ResponseDto> appleLogin(@RequestBody AppleRequestDto appleUser) throws JsonProcessingException, SQLException, ParseException {
+        UserCheckDto checkDto = oauthService.getAppleUser(appleUser);
 
         String token = jwtService.createToken(new JwtPayload(checkDto.getUserId()));
 

--- a/src/main/java/com/yapp/ios1/controller/UserController.java
+++ b/src/main/java/com/yapp/ios1/controller/UserController.java
@@ -16,6 +16,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.ibatis.executor.ExecutorException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -48,7 +49,7 @@ public class UserController {
             value = "이메일 존재 여부"
     )
     @PostMapping("/email-check")
-    public ResponseEntity<ResponseDto> emailCheck(@RequestBody EmailCheckDto emailDto) throws SQLException {
+    public ResponseEntity<ResponseDto> emailCheck(@RequestBody EmailCheckDto emailDto) {
         Optional<UserDto> user = userService.emailCheck(emailDto.getEmail());
         if (user.isEmpty()) {
             return ResponseEntity.ok().body(ResponseDto.of(HttpStatus.NOT_FOUND, NOT_EXIST_USER));
@@ -65,7 +66,7 @@ public class UserController {
             value = "닉네임 존재 여부"
     )
     @PostMapping("/nickname-check")
-    public ResponseEntity<ResponseDto> nicknameCheck(@RequestBody NicknameCheckDto nicknameDto) throws SQLException {
+    public ResponseEntity<ResponseDto> nicknameCheck(@RequestBody NicknameCheckDto nicknameDto) {
         Optional<UserDto> user = userService.nicknameCheck(nicknameDto.getNickname());
         if (user.isEmpty()) {
             return ResponseEntity.ok().body(ResponseDto.of(HttpStatus.NOT_FOUND, NOT_EXIST_USER));
@@ -102,7 +103,7 @@ public class UserController {
             value = "로그인"
     )
     @PostMapping("/signin")
-    public ResponseEntity<ResponseDto> signIn(@RequestBody SignInDto signInDto) throws JsonProcessingException, SQLException {
+    public ResponseEntity<ResponseDto> signIn(@RequestBody SignInDto signInDto) throws JsonProcessingException {
         UserDto userDto = userService.getUser(signInDto);
         String token = jwtService.createToken(new JwtPayload(userDto.getId()));
         ResponseDto response = ResponseDto.of(HttpStatus.OK, LOGIN_SUCCESS, new TokenDto(token));

--- a/src/main/java/com/yapp/ios1/dto/user/SignUpDto.java
+++ b/src/main/java/com/yapp/ios1/dto/user/SignUpDto.java
@@ -1,5 +1,6 @@
 package com.yapp.ios1.dto.user;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.yapp.ios1.dto.user.social.SocialType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,9 +14,11 @@ import lombok.Getter;
 @Getter
 public class SignUpDto {
     private String email;
+    @JsonIgnore
     private SocialType socialType;
     private String password;
     private String nickname;
     private String intro;
+    @JsonIgnore
     private String socialId;
 }

--- a/src/main/java/com/yapp/ios1/dto/user/UserDto.java
+++ b/src/main/java/com/yapp/ios1/dto/user/UserDto.java
@@ -24,6 +24,7 @@ public class UserDto {
     private String createdDate;
     @JsonIgnore
     private String socialId;
+    private String deviceToken;
 
     public UserDto(String email, SocialType socialType, String nickname, String password, String intro) {
         this.email = email;

--- a/src/main/java/com/yapp/ios1/dto/user/social/AppleRequestDto.java
+++ b/src/main/java/com/yapp/ios1/dto/user/social/AppleRequestDto.java
@@ -1,0 +1,14 @@
+package com.yapp.ios1.dto.user.social;
+
+import lombok.Getter;
+
+/**
+ * created by ayoung 2021/05/15
+ */
+@Getter
+public class AppleRequestDto {
+    private String userIdentity;
+    private String name;
+    private String email;
+    private String identityToken;
+}

--- a/src/main/java/com/yapp/ios1/mapper/UserMapper.java
+++ b/src/main/java/com/yapp/ios1/mapper/UserMapper.java
@@ -18,6 +18,8 @@ public interface UserMapper {
 
     Optional<UserDto> findByNickname(@Param("nickname") String nickname);
 
+    Optional<UserDto> findBySocialId(@Param("socialId") String socialId);
+
     Optional<UserDto> findByEmailOrNickname(@Param("email") String email, @Param("nickname") String nickname);
 
     void signUp(UserDto userDto);

--- a/src/main/java/com/yapp/ios1/service/JwtService.java
+++ b/src/main/java/com/yapp/ios1/service/JwtService.java
@@ -2,6 +2,8 @@ package com.yapp.ios1.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jwt.ReadOnlyJWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
 import com.yapp.ios1.dto.JwtPayload;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.SignatureException;
@@ -12,7 +14,7 @@ import org.springframework.stereotype.Service;
 import javax.crypto.spec.SecretKeySpec;
 import javax.xml.bind.DatatypeConverter;
 import java.security.Key;
-import java.util.Calendar;
+import java.text.ParseException;
 import java.util.Date;
 
 /**
@@ -48,6 +50,13 @@ public class JwtService {
                 .getBody();
 
         return objectMapper.readValue(claims.getSubject(), JwtPayload.class);
+    }
+
+    public String getSubject(String identityToken) throws ParseException {
+        SignedJWT signedJWT = SignedJWT.parse(identityToken);
+        ReadOnlyJWTClaimsSet payload = signedJWT.getJWTClaimsSet();
+
+        return payload.getSubject();
     }
 }
 

--- a/src/main/java/com/yapp/ios1/service/OauthService.java
+++ b/src/main/java/com/yapp/ios1/service/OauthService.java
@@ -45,7 +45,7 @@ public class OauthService {
     @Value("${social.url.kakao}")
     private String KAKAO_REQUEST_URL;
 
-    public UserCheckDto getSocialUser(String socialType, String accessToken) throws JsonProcessingException, SQLException {
+    public UserCheckDto getSocialUser(String socialType, String accessToken) throws JsonProcessingException {
         try {
             switch (SocialType.valueOf(socialType.toUpperCase())) {
                 case GOOGLE:
@@ -79,7 +79,7 @@ public class OauthService {
     }
 
     // 구글 로그인
-    private UserCheckDto getGoogleUser(String accessToken) throws JsonProcessingException, SQLException, HttpClientErrorException {
+    private UserCheckDto getGoogleUser(String accessToken) throws JsonProcessingException, HttpClientErrorException {
         JsonNode profile = getProfile(accessToken, GOOGLE_REQUEST_URL);
         String userEmail = profile.get("email").textValue();
 
@@ -97,7 +97,7 @@ public class OauthService {
     }
 
     // 카카오 로그인
-    private UserCheckDto getKakaoUser(String accessToken) throws JsonProcessingException, SQLException {
+    private UserCheckDto getKakaoUser(String accessToken) throws JsonProcessingException {
         JsonNode profile = getProfile(accessToken, KAKAO_REQUEST_URL);
         String userEmail = profile.get("kakao_account").get("email").textValue();
 
@@ -115,7 +115,7 @@ public class OauthService {
     }
 
     // 애플 로그인
-    public UserCheckDto getAppleUser(AppleRequestDto appleUser) throws ParseException, SQLException {
+    public UserCheckDto getAppleUser(AppleRequestDto appleUser) throws ParseException {
 
         if (!jwtService.getSubject(appleUser.getIdentityToken()).equals(appleUser.getUserIdentity())) {
             throw new IllegalArgumentException(SOCIAL_LOGIN_ERROR);
@@ -126,7 +126,7 @@ public class OauthService {
 
         if (optionalUser.isEmpty()) {
             if (userService.emailCheck(appleUser.getEmail()).isPresent()) { // 이메일 중복 확인
-                throw new UserDuplicatedException(EXIST_USER);
+                throw new UserDuplicatedException(EXIST_EMAIL);
             }
             SignUpDto signUpDto = SignUpDto.builder()
                     .email(appleUser.getEmail())

--- a/src/main/java/com/yapp/ios1/service/UserService.java
+++ b/src/main/java/com/yapp/ios1/service/UserService.java
@@ -62,6 +62,19 @@ public class UserService {
     }
 
     /**
+     * 소셜 ID 존재하는지 확인
+     *
+     * @param socialId 소셜 아이디
+     */
+    public Optional<UserDto> socialIdCheck(String socialId) throws SQLException {
+        try {
+            return userMapper.findBySocialId(socialId);
+        } catch (Exception e) {
+            throw new SQLException(DATABASE_ERROR);
+        }
+    }
+
+    /**
      * 이메일 or 닉네임 중복 확인
      *
      * @param email    이메일

--- a/src/main/java/com/yapp/ios1/service/UserService.java
+++ b/src/main/java/com/yapp/ios1/service/UserService.java
@@ -40,12 +40,8 @@ public class UserService {
      *
      * @param email 이메일
      */
-    public Optional<UserDto> emailCheck(String email) throws SQLException {
-        try {
-            return userMapper.findByEmail(email);
-        } catch (Exception e) {
-            throw new SQLException(DATABASE_ERROR);
-        }
+    public Optional<UserDto> emailCheck(String email) {
+        return userMapper.findByEmail(email);
     }
 
     /**
@@ -53,12 +49,8 @@ public class UserService {
      *
      * @param nickname 닉네임
      */
-    public Optional<UserDto> nicknameCheck(String nickname) throws SQLException {
-        try {
-            return userMapper.findByNickname(nickname);
-        } catch (Exception e) {
-            throw new SQLException(DATABASE_ERROR);
-        }
+    public Optional<UserDto> nicknameCheck(String nickname) {
+        return userMapper.findByNickname(nickname);
     }
 
     /**
@@ -66,12 +58,8 @@ public class UserService {
      *
      * @param socialId 소셜 아이디
      */
-    public Optional<UserDto> socialIdCheck(String socialId) throws SQLException {
-        try {
-            return userMapper.findBySocialId(socialId);
-        } catch (Exception e) {
-            throw new SQLException(DATABASE_ERROR);
-        }
+    public Optional<UserDto> socialIdCheck(String socialId) {
+        return userMapper.findBySocialId(socialId);
     }
 
     /**
@@ -105,20 +93,16 @@ public class UserService {
      * @param signInDto 로그인 정보
      * @return UserDto 비밀번호 확인까지 완료한 UserDto
      */
-    public UserDto getUser(SignInDto signInDto) throws SQLException {
-        try {
-            Optional<UserDto> optional = emailCheck(signInDto.getEmail());
-            if (optional.isEmpty()) {
-                throw new UserNotFoundException(NOT_EXIST_USER);
-            }
-            UserDto user = optional.get();
-            if (passwordEncoder.matches(signInDto.getPassword(), user.getPassword())) {
-                return user;
-            }
-            throw new PasswordNotMatchException(NOT_MATCH_PASSWORD);
-        } catch (Exception e) {
-            throw new SQLException(DATABASE_ERROR);
+    public UserDto getUser(SignInDto signInDto) {
+        Optional<UserDto> optional = emailCheck(signInDto.getEmail());
+        if (optional.isEmpty()) {
+            throw new UserNotFoundException(NOT_EXIST_USER);
         }
+        UserDto user = optional.get();
+        if (passwordEncoder.matches(signInDto.getPassword(), user.getPassword())) {
+            return user;
+        }
+        throw new PasswordNotMatchException(NOT_MATCH_PASSWORD);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/mapper/userMapper.xml
+++ b/src/main/resources/mapper/userMapper.xml
@@ -22,4 +22,8 @@
     <select id="findByNickname" resultType="UserDto">
         SELECT * FROM user WHERE nickname = #{nickname};
     </select>
+
+    <select id="findBySocialId" resultType="UserDto">
+        SELECT * FROM user WHERE social_id = #{socialId};
+    </select>
 </mapper>

--- a/src/test/java/com/yapp/ios1/service/JwtServiceTest.java
+++ b/src/test/java/com/yapp/ios1/service/JwtServiceTest.java
@@ -1,0 +1,33 @@
+package com.yapp.ios1.service;
+
+import com.nimbusds.jwt.ReadOnlyJWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.text.ParseException;
+import java.util.Date;
+
+/**
+ * 임시 토큰 테스트
+ *
+ * created by ayoung 2021/05/15
+ */
+public class JwtServiceTest {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @Test
+    public void decode_테스트() throws ParseException {
+        SignedJWT signedJWT = SignedJWT.parse("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwiZXhwIjoxNjIyODU5ODk0fQ.nLl9b-mGhDdL7p3jnJzVE6Se07nzFkPnHvKF8mhA_6Q");
+        ReadOnlyJWTClaimsSet payload = signedJWT.getJWTClaimsSet();
+
+        Date currentTime = new Date(System.currentTimeMillis());
+        if (!currentTime.before(payload.getExpirationTime())) {
+            logger.info("유효기간 지남");
+        }
+
+        logger.info("" + payload.getSubject());
+    }
+}


### PR DESCRIPTION
- OauthService의 getAppleUser 메서드 살짝 설명하자면
1. user_identity와 identityToken의 sub(토큰 제목)을 비교한다. 
(user_identity(사용자 식별번호) 유효성 검사가 필요할 듯해서 토큰과 비교를 해 유효성 검사를 진행한 것인데,, 이게 꼭 필요할지 얘기해보면 좋겠습니당!)
2. socialId(== user_identity)가 데베에 존재하는지 체크
3. 존재하지 않으면 회원가입 처리 (이때 중복되는 이메일 있을 시 예외 던짐)
    존재하면 로그인 처리(카카오, 구글과 같음. 단지 social_id 정보를 프론트에서 얻음)
- JwtServiceTest는 토큰의 claim에서 sub값 확인해보는 테스트 해봤습니다! 지울 예정입니다 