### PR TITLE
[YITEAM-68] 프로필 관련 API 구현

### DIFF
--- a/src/main/java/com/yapp/ios1/common/ResponseMessage.java
+++ b/src/main/java/com/yapp/ios1/common/ResponseMessage.java
@@ -27,7 +27,8 @@ public class ResponseMessage {
     public static final String BAD_JWT = "잘못된 JWT 입니다.";
 
     // User
-    public static final String PROFILE_UPDATE_SUCCESS = "프로필 수정 완료.";
+    public static final String GET_PROFILE_SUCCESS = "프로필 가져오기 성공.";
+    public static final String UPDATE_PROFILE_SUCCESS = "프로필 수정 성공.";
     public static final String GET_MY_INFO = "마이페이지 정보입니다.";
     public static final String GET_USER_INFO = "사용자페이지 정보입니다.";
     public static final String GET_FRIEND_LIST = "친구 목록입니다.";

--- a/src/main/java/com/yapp/ios1/common/ResponseMessage.java
+++ b/src/main/java/com/yapp/ios1/common/ResponseMessage.java
@@ -27,6 +27,7 @@ public class ResponseMessage {
     public static final String BAD_JWT = "잘못된 JWT 입니다.";
 
     // User
+    public static final String PROFILE_UPDATE_SUCCESS = "프로필 수정 완료.";
     public static final String GET_MY_INFO = "마이페이지 정보입니다.";
     public static final String GET_USER_INFO = "사용자페이지 정보입니다.";
     public static final String GET_FRIEND_LIST = "친구 목록입니다.";

--- a/src/main/java/com/yapp/ios1/controller/BucketController.java
+++ b/src/main/java/com/yapp/ios1/controller/BucketController.java
@@ -55,7 +55,10 @@ public class BucketController {
      * @param bucket    버킷 등록 정보
      * @param imageList 버킷 이미지 리스트
      */
-    @ApiOperation(value = "버킷 등록")
+    @ApiOperation(
+            value = "버킷 등록",
+            notes = "포스트맨에서 테스트 가능"
+    )
     @Auth
     @PostMapping("/buckets")
     public ResponseEntity<ResponseDto> registerBucket(@RequestPart(value = "image", required = false) MultipartFile[] imageList,

--- a/src/main/java/com/yapp/ios1/controller/OauthController.java
+++ b/src/main/java/com/yapp/ios1/controller/OauthController.java
@@ -14,7 +14,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.sql.SQLException;
 import java.text.ParseException;
 
 import static com.yapp.ios1.common.ResponseMessage.LOGIN_SUCCESS;
@@ -33,7 +32,8 @@ public class OauthController {
     private final JwtService jwtService;
 
     @PostMapping("/{social_type}")
-    public ResponseEntity<ResponseDto> socialLogin(@PathVariable("social_type") String socialType, @RequestBody TokenDto tokenDto) throws JsonProcessingException {
+    public ResponseEntity<ResponseDto> socialLogin(@PathVariable("social_type") String socialType,
+                                                   @RequestBody TokenDto tokenDto) throws JsonProcessingException {
         UserCheckDto checkDto = oauthService.getSocialUser(socialType, tokenDto.getAccessToken());
 
         String token = jwtService.createToken(new JwtPayload(checkDto.getUserId()));

--- a/src/main/java/com/yapp/ios1/controller/UserController.java
+++ b/src/main/java/com/yapp/ios1/controller/UserController.java
@@ -116,21 +116,21 @@ public class UserController {
         return ResponseEntity.ok().body(response);
     }
 
-    @Auth
     @ApiOperation(
             value = "프로필 가져오기"
     )
+    @Auth
     @GetMapping("")
     public ResponseEntity<ResponseDto> getProfile() {
         Long userId = UserContext.getCurrentUserId();
         return ResponseEntity.ok().body(ResponseDto.of(HttpStatus.OK,GET_PROFILE_SUCCESS, userService.getProfile(userId)));
     }
 
-    @Auth
     @ApiOperation(
             value = "프로필 수정",
             notes = "포스트맨에서 테스트 가능"
     )
+    @Auth
     @PutMapping("")
     public ResponseEntity<ResponseDto> updateProfile(@RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
                                                      @RequestPart ProfileDto profile) throws IOException {

--- a/src/main/java/com/yapp/ios1/controller/UserController.java
+++ b/src/main/java/com/yapp/ios1/controller/UserController.java
@@ -118,6 +118,16 @@ public class UserController {
 
     @Auth
     @ApiOperation(
+            value = "프로필 가져오기"
+    )
+    @GetMapping("")
+    public ResponseEntity<ResponseDto> getProfile() {
+        Long userId = UserContext.getCurrentUserId();
+        return ResponseEntity.ok().body(ResponseDto.of(HttpStatus.OK,GET_PROFILE_SUCCESS, userService.getProfile(userId)));
+    }
+
+    @Auth
+    @ApiOperation(
             value = "프로필 수정",
             notes = "포스트맨에서 테스트 가능"
     )
@@ -126,7 +136,7 @@ public class UserController {
                                                      @RequestPart ProfileDto profile) throws IOException {
         Long userId = UserContext.getCurrentUserId();
         userService.updateProfile(profile, profileImage, userId);
-        return ResponseEntity.ok().body(ResponseDto.of(HttpStatus.OK, PROFILE_UPDATE_SUCCESS));
+        return ResponseEntity.ok().body(ResponseDto.of(HttpStatus.OK, UPDATE_PROFILE_SUCCESS));
     }
 
     @ApiOperation(

--- a/src/main/java/com/yapp/ios1/controller/UserController.java
+++ b/src/main/java/com/yapp/ios1/controller/UserController.java
@@ -24,7 +24,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
@@ -112,6 +114,19 @@ public class UserController {
         String token = jwtService.createToken(new JwtPayload(userDto.getId()));
         ResponseDto response = ResponseDto.of(HttpStatus.OK, LOGIN_SUCCESS, new TokenDto(token));
         return ResponseEntity.ok().body(response);
+    }
+
+    @Auth
+    @ApiOperation(
+            value = "프로필 수정",
+            notes = "포스트맨에서 테스트 가능"
+    )
+    @PutMapping("")
+    public ResponseEntity<ResponseDto> updateProfile(@RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
+                                                     @RequestPart ProfileDto profile) throws IOException {
+        Long userId = UserContext.getCurrentUserId();
+        userService.updateProfile(profile, profileImage, userId);
+        return ResponseEntity.ok().body(ResponseDto.of(HttpStatus.OK, PROFILE_UPDATE_SUCCESS));
     }
 
     @ApiOperation(

--- a/src/main/java/com/yapp/ios1/dto/user/ProfileDto.java
+++ b/src/main/java/com/yapp/ios1/dto/user/ProfileDto.java
@@ -1,0 +1,27 @@
+package com.yapp.ios1.dto.user;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * created by ayoung 2021/05/18
+ */
+@AllArgsConstructor
+@Getter
+public class ProfileDto {
+    @JsonIgnore
+    private Long userId;
+    private String nickname;
+    private String intro;
+    @JsonIgnore
+    private String profileUrl;
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public void setProfileUrl(String profileUrl) {
+        this.profileUrl = profileUrl;
+    }
+}

--- a/src/main/java/com/yapp/ios1/dto/user/ProfileResultDto.java
+++ b/src/main/java/com/yapp/ios1/dto/user/ProfileResultDto.java
@@ -1,0 +1,13 @@
+package com.yapp.ios1.dto.user;
+
+import lombok.Getter;
+
+/**
+ * created by ayoung 2021/05/18
+ */
+@Getter
+public class ProfileResultDto {
+    private String nickname;
+    private String intro;
+    private String profileUrl;
+}

--- a/src/main/java/com/yapp/ios1/dto/user/UserDto.java
+++ b/src/main/java/com/yapp/ios1/dto/user/UserDto.java
@@ -27,6 +27,7 @@ public class UserDto {
     private String socialId;
     @JsonIgnore
     private String deviceToken;
+    private String profileUrl;
 
     public UserDto(String email, SocialType socialType, String nickname, String password, String intro) {
         this.email = email;

--- a/src/main/java/com/yapp/ios1/mapper/UserMapper.java
+++ b/src/main/java/com/yapp/ios1/mapper/UserMapper.java
@@ -1,6 +1,7 @@
 package com.yapp.ios1.mapper;
 
 import com.yapp.ios1.dto.user.ProfileDto;
+import com.yapp.ios1.dto.user.ProfileResultDto;
 import com.yapp.ios1.dto.user.UserDto;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -22,6 +23,8 @@ public interface UserMapper {
     Optional<UserDto> findBySocialId(@Param("socialId") String socialId);
 
     Optional<UserDto> findByEmailOrNickname(@Param("email") String email, @Param("nickname") String nickname);
+
+    Optional<ProfileResultDto> findProfileByUserId(@Param("userId") Long userId);
 
     void updateProfile(ProfileDto profileDto);
 

--- a/src/main/java/com/yapp/ios1/mapper/UserMapper.java
+++ b/src/main/java/com/yapp/ios1/mapper/UserMapper.java
@@ -1,5 +1,6 @@
 package com.yapp.ios1.mapper;
 
+import com.yapp.ios1.dto.user.ProfileDto;
 import com.yapp.ios1.dto.user.UserDto;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -12,7 +13,7 @@ import java.util.Optional;
 @Mapper
 public interface UserMapper {
 
-    Optional<UserDto> findByUserId(@Param("userId") long userId);
+    Optional<UserDto> findByUserId(@Param("userId") Long userId);
 
     Optional<UserDto> findByEmail(@Param("email") String email);
 
@@ -21,6 +22,8 @@ public interface UserMapper {
     Optional<UserDto> findBySocialId(@Param("socialId") String socialId);
 
     Optional<UserDto> findByEmailOrNickname(@Param("email") String email, @Param("nickname") String nickname);
+
+    void updateProfile(ProfileDto profileDto);
 
     void signUp(UserDto userDto);
 }

--- a/src/main/java/com/yapp/ios1/service/S3Service.java
+++ b/src/main/java/com/yapp/ios1/service/S3Service.java
@@ -11,14 +11,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.annotation.PostConstruct;
 import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * created by ayoung 2021/03/29
@@ -35,20 +31,20 @@ public class S3Service {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    @Value("${buok.s3.dir}")
-    private String dirName;
+    @Value("${buok.s3.dir.bucket}")
+    private String bucketDir;
 
     public List<String> upload(MultipartFile[] multipartFileList) throws IOException {
         List<String> imageUrlList = new ArrayList<>();
         if (multipartFileList != null) {
             for (MultipartFile multipartFile : multipartFileList) {
-                imageUrlList.add(upload(multipartFile));
+                imageUrlList.add(upload(multipartFile, bucketDir));
             }
         }
         return imageUrlList;
     }
 
-    public String upload(MultipartFile file) throws IOException {
+    public String upload(MultipartFile file, String dirName) throws IOException {
         String fileName = file.getOriginalFilename();
 
         ObjectMetadata objMeta = new ObjectMetadata();
@@ -60,6 +56,7 @@ public class S3Service {
 
         s3Client.putObject(new PutObjectRequest(bucket, dirName + fileName, byteArrayIs, objMeta)
                 .withCannedAcl(CannedAccessControlList.PublicRead));
+
         return s3Client.getUrl(bucket, fileName).toString();
     }
 }

--- a/src/main/java/com/yapp/ios1/service/UserService.java
+++ b/src/main/java/com/yapp/ios1/service/UserService.java
@@ -3,6 +3,7 @@ package com.yapp.ios1.service;
 import com.yapp.ios1.dto.bucket.BookmarkDto;
 import com.yapp.ios1.dto.bucket.BookmarkResultDto;
 import com.yapp.ios1.dto.user.ProfileDto;
+import com.yapp.ios1.dto.user.ProfileResultDto;
 import com.yapp.ios1.dto.user.result.FriendDto;
 import com.yapp.ios1.dto.user.login.SignInDto;
 import com.yapp.ios1.dto.user.UserDto;
@@ -111,6 +112,15 @@ public class UserService {
             return user;
         }
         throw new PasswordNotMatchException(NOT_MATCH_PASSWORD);
+    }
+
+    // 프로필 정보 GET
+    public ProfileResultDto getProfile(Long userId) {
+        Optional<ProfileResultDto> optional = userMapper.findProfileByUserId(userId);
+        if (optional.isEmpty()) {
+            throw new UserNotFoundException(NOT_EXIST_USER);
+        }
+        return optional.get();
     }
 
     // 프로필 업데이트

--- a/src/main/java/com/yapp/ios1/service/UserService.java
+++ b/src/main/java/com/yapp/ios1/service/UserService.java
@@ -2,6 +2,7 @@ package com.yapp.ios1.service;
 
 import com.yapp.ios1.dto.bucket.BookmarkDto;
 import com.yapp.ios1.dto.bucket.BookmarkResultDto;
+import com.yapp.ios1.dto.user.ProfileDto;
 import com.yapp.ios1.dto.user.result.FriendDto;
 import com.yapp.ios1.dto.user.login.SignInDto;
 import com.yapp.ios1.dto.user.UserDto;
@@ -12,10 +13,13 @@ import com.yapp.ios1.mapper.FollowMapper;
 import com.yapp.ios1.mapper.UserMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Optional;
@@ -31,9 +35,13 @@ import static com.yapp.ios1.common.ResponseMessage.*;
 public class UserService {
 
     private final BucketService bucketService;
+    private final S3Service s3Service;
     private final UserMapper userMapper;
     private final PasswordEncoder passwordEncoder;
     private final FollowMapper followMapper;
+
+    @Value("${buok.s3.dir.profile}")
+    private String profileDir;
 
     /**
      * 이메일 존재하는지 확인
@@ -103,6 +111,16 @@ public class UserService {
             return user;
         }
         throw new PasswordNotMatchException(NOT_MATCH_PASSWORD);
+    }
+
+    // 프로필 업데이트
+    @Transactional
+    public void updateProfile(ProfileDto profileDto, MultipartFile profileImage, Long userId) throws IOException {
+        profileDto.setUserId(userId);
+        if (profileImage != null) {
+            profileDto.setProfileUrl(s3Service.upload(profileImage, profileDir));
+        }
+        userMapper.updateProfile(profileDto);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/mapper/userMapper.xml
+++ b/src/main/resources/mapper/userMapper.xml
@@ -27,6 +27,10 @@
         SELECT * FROM user WHERE social_id = #{socialId};
     </select>
 
+    <select id="findProfileByUserId" resultType="ProfileResultDto">
+        SELECT nickname, intro, profile_url as profileUrl FROM user WHERE id = #{userId};
+    </select>
+
     <update id="updateProfile">
         UPDATE user
         SET nickname    = #{nickname},

--- a/src/main/resources/mapper/userMapper.xml
+++ b/src/main/resources/mapper/userMapper.xml
@@ -26,4 +26,12 @@
     <select id="findBySocialId" resultType="UserDto">
         SELECT * FROM user WHERE social_id = #{socialId};
     </select>
+
+    <update id="updateProfile">
+        UPDATE user
+        SET nickname    = #{nickname},
+            intro       = #{intro},
+            profile_url = #{profileUrl}
+        WHERE id = #{userId};
+    </update>
 </mapper>


### PR DESCRIPTION
- 프로필 업데이트 API, 프로필 정보 가져오기 API
- ProfileDto : 프로필 업데이트 요청 바디
ProfileResultDto : 프로필 가져오기 응답 바디
- profileResultDto가 비어있는 경우, `NOT_EXIST_USER`을 반환하게 했는데, 먼저 userId가 존재하는지 확인하는 게 나을지 생각 중입니다!
- 버킷 등록처럼 ProfileDto에 `setUserId, setProfileUrl` 메서드를 이용해서 설정했는데, set을 해도 될지.. 아직 헷갈리네용
- 프로필 사진 S3에 저장할 때 /bucket, /profile 폴더를 나누어서 저장하도록 하였습니다. 
   (yml 파일 경로 : `buok.s3.dir.profile, buok.s3.dir.bucket`)
   
- 프로필 업데이트 응답 body
```json
{
    "status": 200,
    "message": "프로필 수정 완료.",
    "data": null
}
```
- 프로필 가져오기 응답 body
```json
{
  "status": 200,
  "message": "프로필 가져오기 성공.",
  "data": {
    "nickname": "애용ㅋ",
    "intro": "수정테스트다요",
    "profileUrl": "https://a~"
  }
}
```