### PR TITLE
[YITEAM-113] 프로필 수정 쿼리문 수정

### DIFF
--- a/src/main/java/com/yapp/ios1/common/ResponseMessage.java
+++ b/src/main/java/com/yapp/ios1/common/ResponseMessage.java
@@ -28,6 +28,7 @@ public class ResponseMessage {
     public static final String EXIST_EMAIL = "존재하는 이메일입니다.";
     public static final String NOT_EXIST_EMAIL = "이메일을 입력해주세요.";
     public static final String EXIST_USER = "존재하는 회원입니다.";
+    public static final String EXIST_NICKNAME = "닉네임 중복입니다.";
     public static final String NOT_EXIST_USER = "존재하지 않는 회원입니다.";
     public static final String SIGN_UP_SUCCESS = "회원가입 성공입니다.";
     public static final String NOT_MATCH_PASSWORD = "비밀번호 오류입니다.";

--- a/src/main/java/com/yapp/ios1/mapper/UserMapper.java
+++ b/src/main/java/com/yapp/ios1/mapper/UserMapper.java
@@ -29,7 +29,7 @@ public interface UserMapper {
 
     void changePassword(Long userId, String password);
 
-    void updateProfile(ProfileDto profile, Long userId);
+    int updateProfile(ProfileDto profile, Long userId);
 
     void signUp(UserDto userDto);
 

--- a/src/main/java/com/yapp/ios1/service/UserService.java
+++ b/src/main/java/com/yapp/ios1/service/UserService.java
@@ -7,6 +7,7 @@ import com.yapp.ios1.dto.user.ProfileResultDto;
 import com.yapp.ios1.dto.user.UserDto;
 import com.yapp.ios1.dto.user.login.SignInDto;
 import com.yapp.ios1.dto.user.result.UserInfoDto;
+import com.yapp.ios1.exception.common.BadRequestException;
 import com.yapp.ios1.exception.user.PasswordNotMatchException;
 import com.yapp.ios1.exception.user.UserNotFoundException;
 import com.yapp.ios1.mapper.FollowMapper;
@@ -124,8 +125,10 @@ public class UserService {
     // 프로필 업데이트
     @Transactional
     public void updateProfile(ProfileDto profileDto, Long userId) {
-        // 닉네임 중복 확인해야함 (자기 자신 별명 제외)
-        userMapper.updateProfile(profileDto, userId);
+        int change = userMapper.updateProfile(profileDto, userId);
+        if (change == 0) { // 닉네임 중복인 경우
+            throw new BadRequestException(EXIST_NICKNAME);
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/resources/mapper/userMapper.xml
+++ b/src/main/resources/mapper/userMapper.xml
@@ -38,11 +38,21 @@
     </update>
 
     <update id="updateProfile">
-        UPDATE user
-        SET nickname    = #{profile.nickname},
-            intro       = #{profile.intro},
-            profile_url = #{profile.profileUrl}
-        WHERE id = #{userId};
+        UPDATE
+            user AS a
+        SET a.nickname    = #{profile.nickname},
+            a.intro       = #{profile.intro},
+            a.profile_url = #{profile.profileUrl}
+        WHERE (
+            SELECT c.nickname as nickname
+            FROM (
+                     SELECT b.nickname as nickname
+                     FROM user AS b
+                     WHERE b.id NOT IN (#{userId})
+                 ) as c
+            WHERE c.nickname IN (#{profile.nickname})
+        ) IS NULL
+          AND a.id = #{userId};
     </update>
 
     <select id="findDeviceTokenByUserId" resultType="String">


### PR DESCRIPTION
- 자기 자신을 제외한 닉네임 중복 확인하는 쿼리문으로 수정
- 서브 쿼리이 나을지, 디비 조회를 여러 번 하는 게 좋을지 논의 후, 리팩토링 할 예정
- 변경이 없다면 닉네임 중복으로 인한 변경 실패로 반환했습니다! (`change = 0`)
- 일단 BadRequestException으로 예외 던졌는데, Exception 클래스를 따로 추가하는 게 나을지 얘기하면 좋을 것 같습니담
- 수정 성공 시 응답
```json
{
  "status": 200,
  "message": "프로필 수정 성공입니다.",
  "data": null
}
```
- 닉네임 중복 응답
```json
{
  "status": 400,
  "message": "닉네임 중복입니다.",
  "data": null
}
```
