### PR TITLE
[YITEAM-118] 요청 데이터 유효성 검사 추가

### DIFF
--- a/src/main/java/com/yapp/ios1/advice/BucketAdviceController.java
+++ b/src/main/java/com/yapp/ios1/advice/BucketAdviceController.java
@@ -11,6 +11,10 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.time.format.DateTimeParseException;
+
+import static com.yapp.ios1.common.ResponseMessage.NOT_VALID_DATE_TIME;
+
 /**
  * created by jg 2021/05/09
  */
@@ -41,5 +45,11 @@ public class BucketAdviceController {
     public ResponseEntity<ResponseDto> failedUpdate(FailedUpdateException e) {
         return ResponseEntity.ok()
                 .body(ResponseDto.of(HttpStatus.BAD_REQUEST, e.getMessage()));
+    }
+
+    @ExceptionHandler(DateTimeParseException.class)
+    public ResponseEntity<ResponseDto> dateTimeParseException() {
+        return ResponseEntity.ok()
+                .body(ResponseDto.of(HttpStatus.BAD_REQUEST, NOT_VALID_DATE_TIME));
     }
 }

--- a/src/main/java/com/yapp/ios1/common/ResponseMessage.java
+++ b/src/main/java/com/yapp/ios1/common/ResponseMessage.java
@@ -70,5 +70,6 @@ public class ResponseMessage {
     public static final String NOT_VALID_CATEGORY_ID = "유효한 카테고리 ID가 아닙니다.";
     public static final String NOT_VALID_STATE = "유효한 버킷 state가 아닙니다.";
     public static final String NOT_VALID_DATE_TIME = "날짜 형식 yyyy-MM-dd 입니다.";
+    public static final String NOT_VALID_EMAIL = "이메일 형식 제대로 입력해주세요.";
 
 }

--- a/src/main/java/com/yapp/ios1/common/ResponseMessage.java
+++ b/src/main/java/com/yapp/ios1/common/ResponseMessage.java
@@ -65,4 +65,10 @@ public class ResponseMessage {
     public static final String EMAIL_AUTH_SUCCESS = "이메일 인증 성공입니다.";
     public static final String EMAIL_AUTH_FAIL = "이메일 인증 실패입니다.";
 
+    // Valid
+    public static final String NOT_VALID_BUCKET_NAME = "버킷 제목 작성 필수입니다.";
+    public static final String NOT_VALID_CATEGORY_ID = "유효한 카테고리 ID가 아닙니다.";
+    public static final String NOT_VALID_STATE = "유효한 버킷 state가 아닙니다.";
+    public static final String NOT_VALID_DATE_TIME = "날짜 형식 yyyy-MM-dd 입니다.";
+
 }

--- a/src/main/java/com/yapp/ios1/controller/BucketController.java
+++ b/src/main/java/com/yapp/ios1/controller/BucketController.java
@@ -56,7 +56,7 @@ public class BucketController {
     )
     @Auth
     @PostMapping("")
-    public ResponseEntity<ResponseDto> registerBucket(@RequestBody BucketRequestDto bucket) throws IllegalArgumentException {
+    public ResponseEntity<ResponseDto> registerBucket(@RequestBody @Valid BucketRequestDto bucket) throws IllegalArgumentException {
         bucket.setUserId(UserContext.getCurrentUserId());
         bucketService.registerBucket(bucket);
         return ResponseEntity.ok()

--- a/src/main/java/com/yapp/ios1/controller/EmailController.java
+++ b/src/main/java/com/yapp/ios1/controller/EmailController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.validation.Valid;
 import java.util.Optional;
 
 import static com.yapp.ios1.common.ResponseMessage.*;
@@ -41,7 +42,7 @@ public class EmailController {
             notes = "입력한 이메일로 인증 코드를 전송합니다."
     )
     @PostMapping("/send")
-    public ResponseEntity<ResponseDto> emailAuth(@RequestBody EmailDto email) throws Exception {
+    public ResponseEntity<ResponseDto> emailAuth(@RequestBody @Valid EmailDto email) throws Exception {
         Optional<UserDto> user = userService.emailCheck(email.getEmail());
         if (user.isEmpty()) {
             return ResponseEntity.ok().body(ResponseDto.of(HttpStatus.NOT_FOUND, NOT_EXIST_USER));

--- a/src/main/java/com/yapp/ios1/controller/UserController.java
+++ b/src/main/java/com/yapp/ios1/controller/UserController.java
@@ -22,6 +22,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.sql.SQLException;
 import java.util.Optional;
 
@@ -49,7 +50,7 @@ public class UserController {
             value = "이메일 존재 여부"
     )
     @PostMapping("/email-check")
-    public ResponseEntity<ResponseDto> emailCheck(@RequestBody EmailDto emailDto) {
+    public ResponseEntity<ResponseDto> emailCheck(@RequestBody @Valid EmailDto emailDto) {
         Optional<UserDto> user = userService.emailCheck(emailDto.getEmail());
         if (user.isEmpty()) {
             return ResponseEntity.ok().body(ResponseDto.of(HttpStatus.NOT_FOUND, NOT_EXIST_USER));
@@ -83,7 +84,7 @@ public class UserController {
             value = "회원가입"
     )
     @PostMapping("/signup")
-    public ResponseEntity<ResponseDto> signUp(@RequestBody SignUpDto signUpDto) throws SQLException, JsonProcessingException {
+    public ResponseEntity<ResponseDto> signUp(@RequestBody @Valid SignUpDto signUpDto) throws SQLException, JsonProcessingException {
         Optional<UserDto> user = userService.signUpCheck(signUpDto.getEmail(), signUpDto.getNickname());
         if (user.isPresent()) {
             throw new UserDuplicatedException(EXIST_USER);
@@ -104,7 +105,7 @@ public class UserController {
             notes = "로그인 성공 시, accessToken과 refreshToken을 발급합니다."
     )
     @PostMapping("/signin")
-    public ResponseEntity<ResponseDto> signIn(@RequestBody SignInDto signInDto) throws JsonProcessingException {
+    public ResponseEntity<ResponseDto> signIn(@RequestBody @Valid SignInDto signInDto) throws JsonProcessingException {
         UserDto userDto = userService.getUser(signInDto);
         ResponseDto response = ResponseDto.of(HttpStatus.OK, LOGIN_SUCCESS, jwtService.createTokenResponse(userDto.getId()));
         return ResponseEntity.ok().body(response);

--- a/src/main/java/com/yapp/ios1/dto/bucket/BucketRequestDto.java
+++ b/src/main/java/com/yapp/ios1/dto/bucket/BucketRequestDto.java
@@ -3,8 +3,15 @@ package com.yapp.ios1.dto.bucket;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
 
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import java.time.LocalDate;
 import java.util.List;
+
+import static com.yapp.ios1.common.ResponseMessage.*;
 
 /**
  * created by ayoung 2021/05/08
@@ -17,11 +24,16 @@ public class BucketRequestDto {
     private Long id;
     @JsonIgnore
     private Long userId;
+    @NotBlank(message = NOT_VALID_BUCKET_NAME)
     private String bucketName;
+    @Min(value = 2, message = NOT_VALID_STATE)
+    @Max(value = 4, message = NOT_VALID_STATE)
     private int state;
+    @Min(value = 2, message = NOT_VALID_CATEGORY_ID)
+    @Max(value = 10, message = NOT_VALID_CATEGORY_ID)
     private int categoryId;
-    private String startDate;
-    private String endDate;
+    private LocalDate startDate;
+    private LocalDate endDate;
     private String content;
     private List<String> imageList;
     private List<String> tagList;

--- a/src/main/java/com/yapp/ios1/dto/user/check/EmailDto.java
+++ b/src/main/java/com/yapp/ios1/dto/user/check/EmailDto.java
@@ -3,10 +3,15 @@ package com.yapp.ios1.dto.user.check;
 import lombok.Getter;
 import lombok.Setter;
 
+import javax.validation.constraints.Email;
+
+import static com.yapp.ios1.common.ResponseMessage.NOT_VALID_EMAIL;
+
 /**
  * created by ayoung 2021/04/20
  */
 @Getter
 public class EmailDto {
+    @Email(message = NOT_VALID_EMAIL)
     private String email;
 }

--- a/src/main/java/com/yapp/ios1/dto/user/login/SignInDto.java
+++ b/src/main/java/com/yapp/ios1/dto/user/login/SignInDto.java
@@ -3,12 +3,17 @@ package com.yapp.ios1.dto.user.login;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import javax.validation.constraints.Email;
+
+import static com.yapp.ios1.common.ResponseMessage.NOT_VALID_EMAIL;
+
 /**
  * created by ayoung 2021/04/15
  */
 @AllArgsConstructor
 @Getter
 public class SignInDto {
+    @Email(message = NOT_VALID_EMAIL)
     private String email;
     private String password;
 }

--- a/src/main/java/com/yapp/ios1/dto/user/login/SignUpDto.java
+++ b/src/main/java/com/yapp/ios1/dto/user/login/SignUpDto.java
@@ -6,6 +6,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import javax.validation.constraints.Email;
+
+import static com.yapp.ios1.common.ResponseMessage.NOT_VALID_EMAIL;
+
 /**
  * created by ayoung 2021/04/14
  */
@@ -13,6 +17,7 @@ import lombok.Getter;
 @Builder
 @Getter
 public class SignUpDto {
+    @Email(message = NOT_VALID_EMAIL)
     private String email;
     @JsonIgnore
     private SocialType socialType;


### PR DESCRIPTION
- 버킷 이름 빈칸인 경우
```json
{
  "status": 400,
  "message": "  : 버킷 제목 작성 필수입니다.",
  "data": null
}
```

- 시작 날짜/완료 날짜 LocalDate 포맷(yyyy-MM-dd) 아닌 경우
```json
{
  "status": 400,
  "message": "날짜 형식 yyyy-MM-dd 입니다.",
  "data": null
}
```

- 카테고리 ID 2 미만, 10 초과 입력한 경우
```json
{
  "status": 400,
  "message": "11 : 유효한 카테고리 ID가 아닙니다.",
  "data": null
}
```

- state 2 미만, 4 초과 입력한 경우
```json
{
  "status": 400,
  "message": "1 : 유효한 버킷 state가 아닙니다.",
  "data": null
}
```

- 이메일 데이터 유효성 검사
```json
{
  "status": 400,
  "message": "da@ : 이메일 형식 제대로 입력해주세요.",
  "data": null
}
```