### PR TITLE
[YITEAM-156] 소셜 로그인 수정

### DIFF
--- a/src/main/java/com/yapp/ios1/controller/dto/user/social/SocialLoginDto.java
+++ b/src/main/java/com/yapp/ios1/controller/dto/user/social/SocialLoginDto.java
@@ -1,6 +1,7 @@
 package com.yapp.ios1.controller.dto.user.social;
 
 import lombok.Getter;
+import lombok.Setter;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
@@ -11,6 +12,7 @@ import javax.validation.constraints.NotNull;
  */
 @Getter
 public class SocialLoginDto {
+    @NotNull
     @Email
     private String email;
     @NotBlank

--- a/src/main/java/com/yapp/ios1/service/OauthService.java
+++ b/src/main/java/com/yapp/ios1/service/OauthService.java
@@ -37,8 +37,7 @@ public class OauthService {
         Optional<User> optionalUser = userFindService.findBySocialIdAndSocialType(socialId, socialType);
 
         if (optionalUser.isEmpty()) {
-            // TODO null 처리 다시 확인하기
-            if (email != null) {
+            if (!email.equals("")) {
                 userValidator.checkEmailDuplicate(email);
             }
             return socialSignUp(socialType, socialDto);

--- a/src/main/resources/mapper/userMapper.xml
+++ b/src/main/resources/mapper/userMapper.xml
@@ -6,8 +6,8 @@
     <insert id="signUp" useGeneratedKeys="true" keyProperty="id">
         <choose>
             <when test='email ==  ""'>
-                INSERT INTO user (email, social_type, password, nickname, intro, social_id, device_token)
-                VALUES (null, #{socialType}, #{password}, #{nickname}, #{intro}, #{socialId}, #{deviceToken})
+                INSERT INTO user (social_type, password, nickname, intro, social_id, device_token)
+                VALUES (#{socialType}, #{password}, #{nickname}, #{intro}, #{socialId}, #{deviceToken})
             </when>
             <otherwise>
                 INSERT INTO user (email, social_type, password, nickname, intro, social_id, device_token)

--- a/src/main/resources/mapper/userMapper.xml
+++ b/src/main/resources/mapper/userMapper.xml
@@ -4,8 +4,16 @@
 
 <mapper namespace="com.yapp.ios1.mapper.UserMapper">
     <insert id="signUp" useGeneratedKeys="true" keyProperty="id">
-        INSERT INTO user (email, social_type, password, nickname, intro, social_id, device_token)
-        VALUES (#{email}, #{socialType}, #{password}, #{nickname}, #{intro}, #{socialId}, #{deviceToken})
+        <choose>
+            <when test='email ==  ""'>
+                INSERT INTO user (email, social_type, password, nickname, intro, social_id, device_token)
+                VALUES (null, #{socialType}, #{password}, #{nickname}, #{intro}, #{socialId}, #{deviceToken})
+            </when>
+            <otherwise>
+                INSERT INTO user (email, social_type, password, nickname, intro, social_id, device_token)
+                VALUES (#{email}, #{socialType}, #{password}, #{nickname}, #{intro}, #{socialId}, #{deviceToken})
+            </otherwise>
+        </choose>
     </insert>
 
     <select id="findByUserId" resultType="User">


### PR DESCRIPTION
- 소셜로그인할 때 이메일 존재하지 않는 경우, 빈 문자열("")로 요청하도록 수정(기존: null)
  - mybatis choose, when 문법으로 처리하였습니다!  
  (이게 나을지, `setEmail(null)` 로 하는 게 좋을지.. 아니면 다른 의견 있으면 알려주세요!)